### PR TITLE
URL relations can now be added as a query include

### DIFF
--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Artist.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Artist.cs
@@ -86,6 +86,9 @@ namespace Hqub.MusicBrainz.API.Entities
         [XmlElement("release-list")]
         public ReleaseList ReleaseLists { get; set; }
 
+        [XmlElement("relation-list")]
+        public RelationList RelationLists { get; set; }
+
         [XmlElement("work-list")]
         public WorkList Works { get; set; }
 

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Collections/RelationList.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Collections/RelationList.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Hqub.MusicBrainz.API.Entities.Collections
+{
+    [XmlRoot("relation-list", Namespace = "http://musicbrainz.org/ns/mmd-2.0#")]
+    public class RelationList : BaseList
+    {
+        /// <summary>
+        /// Gets or sets the relation target type.
+        /// </summary>
+        [XmlAttribute("target-type")]
+        public string TargetType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of relations.
+        /// </summary>
+        [XmlElement("relation")]
+        public List<Relation> Items { get; set; }
+    }
+}

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Include/ArtistIncludeEntityHelper.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Include/ArtistIncludeEntityHelper.cs
@@ -21,7 +21,7 @@ namespace Hqub.MusicBrainz.API.Entities.Include
 //        public const string RecordingRelation = "recording-rels";
 //        public const string ReleaseRelation = "release-rels";
 //        public const string ReleaseGroupRelation = "release-group-rels";
-//        public const string UrlRelation = "url-rels";
+        public const string UrlRelation = "url-rels";
 //        public const string WorkRelation = "work-rels";
 
 

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Relation.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Relation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Hqub.MusicBrainz.API.Entities.Collections;
+using Hqub.MusicBrainz.API.Entities.Metadata;
+
+namespace Hqub.MusicBrainz.API.Entities
+{
+    [XmlRoot("relation", Namespace = "http://musicbrainz.org/ns/mmd-2.0#")]
+    public class Relation : Entity
+    {
+        public const string EntityName = "relation";
+
+        /// <summary>
+        /// Gets or sets the relation type.
+        /// </summary>
+        [XmlAttribute("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relation type ID.
+        /// </summary>
+        [XmlAttribute("type-id")]
+        public string TypeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relation target.
+        /// </summary>
+        [XmlElement("target")]
+        public string Target { get; set; }
+    }
+}

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Hqub.MusicBrainz.API.csproj
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Hqub.MusicBrainz.API.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Entities\Collections\MediumList.cs" />
     <Compile Include="Entities\Collections\RecordingList.cs" />
     <Compile Include="Entities\Collections\ReleaseGroupList.cs" />
+    <Compile Include="Entities\Collections\RelationList.cs" />
     <Compile Include="Entities\Collections\ReleaseList.cs" />
     <Compile Include="Entities\Collections\TagList.cs" />
     <Compile Include="Entities\Collections\TrackList.cs" />
@@ -78,6 +79,7 @@
     <Compile Include="Entities\NameCredit.cs" />
     <Compile Include="Entities\Rating.cs" />
     <Compile Include="Entities\Recording.cs" />
+    <Compile Include="Entities\Relation.cs" />
     <Compile Include="Entities\Release.cs" />
     <Compile Include="Entities\ReleaseGroup.cs" />
     <Compile Include="Entities\Tag.cs" />


### PR DESCRIPTION
I wanted to be able to retrieve URLs to external sites, so this seemed to be the obvious thing to do.

Does it make sense for you to pull this?  

Given that all the "rels" include entities were commented out, I suspect there might be a reason that this has not already been done (perhaps the different "rels" have different properties).  Or maybe it was just not needed until now?