### PR TITLE
Include entity relationships

### DIFF
--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Artist.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Artist.cs
@@ -93,14 +93,14 @@ namespace Hqub.MusicBrainz.API.Entities
         [DataMember(Name = "releases")]
         public List<Release> Releases { get; set; }
 
-        [DataMember(Name = "relations")]
-        public List<Relation> Relations { get; set; }
-
         [DataMember(Name = "works")]
         public List<Work> Works { get; set; }
 
         [DataMember(Name = "tags")]
         public List<Tag> Tags { get; set; }
+
+        [DataMember(Name = "relations")]
+        public List<Relation> Relations { get; set; }
 
         #endregion
 

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Rating.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Rating.cs
@@ -15,6 +15,7 @@ namespace Hqub.MusicBrainz.API.Entities
         /// <summary>
         /// Gets or sets the rating value.
         /// </summary>
+        [DataMember(Name = "value")]
         public double Value { get; set; }
     }
 }

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Recording.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Recording.cs
@@ -44,6 +44,12 @@ namespace Hqub.MusicBrainz.API.Entities
         [DataMember(Name = "disambiguation")]
         public string Disambiguation { get; set; }
 
+        /// <summary>
+        /// Gets or sets the rating.
+        /// </summary>
+        [DataMember(Name = "rating")]
+        public Rating Rating { get; set; }
+
         #endregion
 
         #region Include
@@ -56,6 +62,9 @@ namespace Hqub.MusicBrainz.API.Entities
 
         [DataMember(Name = "releases")]
         public List<Release> Releases { get; set; }
+
+        [DataMember(Name = "relations")]
+        public List<Relation> Relations { get; set; }
 
         #endregion
 

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Relation.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Relation.cs
@@ -21,9 +21,52 @@ namespace Hqub.MusicBrainz.API.Entities
         public string TypeId { get; set; }
 
         /// <summary>
-        /// Gets or sets the relation target.
+        /// Gets or sets the relation target type.
         /// </summary>
-        [DataMember(Name = "target")]
-        public string Target { get; set; }
+        [DataMember(Name = "target-type")]
+        public string TargetType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relation direction.
+        /// </summary>
+        [DataMember(Name = "direction")]
+        public string Direction { get; set; }
+
+        // NOTE: using derived classes and the KnownTypes arttibute does not work,
+        //       so we add the relations explicitly (at the moment, only url-rels
+        //       are included).
+        
+        /// <summary>
+        /// Gets or sets the url relationship (include url-rels).
+        /// </summary>
+        [DataMember(Name = "url")]
+        public Url Url { get; set; }
+
+        // Other relationships:
+        //
+        //   /// <summary>
+        //   /// Gets or sets the artist relationship (include artist-rels).
+        //   /// </summary>
+        //   [DataMember(Name = "artist")]
+        //   public Artist Artist { get; set; }
+        //
+        //   /// <summary>
+        //   /// Gets or sets the work relationship (include work-rels).
+        //   /// </summary>
+        //   [DataMember(Name = "work")]
+        //   public Work Work { get; set; }
+        //
+        //   /// <summary>
+        //   /// Gets or sets the release relationship (include release-rels).
+        //   /// </summary>
+        //   [DataMember(Name = "release")]
+        //   public Release Release { get; set; }
+        //
+        //   /// <summary>
+        //   /// Gets or sets the release relationship (include release-rels).
+        //   /// </summary>
+        //   [DataMember(Name = "release")]
+        //   public Release Release { get; set; }
+        //
     }
 }

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Release.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Release.cs
@@ -93,6 +93,9 @@ namespace Hqub.MusicBrainz.API.Entities
         [DataMember(Name = "media")]
         public List<Medium> Media { get; set; }
 
+        [DataMember(Name = "relations")]
+        public List<Relation> Relations { get; set; }
+
         #endregion
 
         #region Static Methods

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/ReleaseGroup.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/ReleaseGroup.cs
@@ -51,7 +51,7 @@ namespace Hqub.MusicBrainz.API.Entities
         public List<string> SecondaryTypes { get; set; }
 
         /// <summary>
-        /// Gets or sets the rating".
+        /// Gets or sets the rating.
         /// </summary>
         [DataMember(Name = "rating")]
         public Rating Rating { get; set; }
@@ -71,6 +71,9 @@ namespace Hqub.MusicBrainz.API.Entities
 
         [DataMember(Name = "releases")]
         public List<Release> Releases { get; set; }
+
+        [DataMember(Name = "relations")]
+        public List<Relation> Relations { get; set; }
 
         #endregion
 

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Url.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Entities/Url.cs
@@ -1,0 +1,21 @@
+﻿
+namespace Hqub.MusicBrainz.API.Entities
+{
+    using System.Runtime.Serialization;
+    
+    [DataContract(Name = "url")]
+    public class Url
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [DataMember(Name = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resource.
+        /// </summary>
+        [DataMember(Name = "resource")]
+        public string Resource { get; set; }
+    }
+}

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Hqub.MusicBrainz.API.csproj
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/Hqub.MusicBrainz.API.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Entities\Tag.cs" />
     <Compile Include="Entities\TextRepresentation.cs" />
     <Compile Include="Entities\Track.cs" />
+    <Compile Include="Entities\Url.cs" />
     <Compile Include="Entities\Work.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryParameters.cs" />

--- a/Hqub.MusicBrainz/Hqub.MusicBrainz.API/WebRequestHelper.cs
+++ b/Hqub.MusicBrainz/Hqub.MusicBrainz.API/WebRequestHelper.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Runtime.Serialization.Json;
-using System.Threading.Tasks;
-
+﻿
 namespace Hqub.MusicBrainz.API
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Runtime.Serialization.Json;
+    using System.Threading.Tasks;
+
     internal static class WebRequestHelper
     {
         private const string WebServiceUrl = "http://musicbrainz.org/ws/2/";
@@ -28,7 +29,7 @@ namespace Hqub.MusicBrainz.API
                 {
                     throw new NullReferenceException(Resources.Messages.EmptyStream);
                 }
-
+                
                 var serializer = new DataContractJsonSerializer(typeof(T));
 
                 return (T)serializer.ReadObject(stream);

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Implementation MuzicBrainze API 2.0 (C#). Current version: 1.0.1
 [![NuGet](https://img.shields.io/nuget/dt/MusicBrainzAPI.svg)](https://www.nuget.org/packages/MusicBrainzAPI/1.0.0)
 [![Issues](https://img.shields.io/github/issues/avatar29A/MusicBrainz.svg)](https://github.com/avatar29A/MusicBrainz/issues)
 
-##Examples:
+## Examples:
 
-######Get Artist by Id.
+##### Get Artist by Id.
 
 ```c#
  static void Main(string[] args)
@@ -22,7 +22,7 @@ Implementation MuzicBrainze API 2.0 (C#). Current version: 1.0.1
  }
 ```
 
-######Search artist by query.
+##### Search artist by query.
 
 ```c#
 
@@ -40,7 +40,7 @@ Implementation MuzicBrainze API 2.0 (C#). Current version: 1.0.1
 
 ```
 
-###### Get Artist with Tags.
+##### Get Artist with Tags.
 
 ```c#
 using Hqub.MusicBrainze.API.Entities;
@@ -60,7 +60,7 @@ static void Main(string[] args)
 }
 ```
 
-###### Show Artist -> Album -> Tracks.
+##### Show Artist -> Album -> Tracks.
 
 ```c#
 private static void Main(string[] args)


### PR DESCRIPTION
At the moment relationships are not implemented. The default serialization doesn't seem to support deserialization of subclasses (Relation <- UrlRelation, ArtistRelation etc.), at least I couldn't get the [KnownTypes method](https://docs.microsoft.com/en-us/dotnet/framework/wcf/samples/known-types) to work.

So one option is to add all types of interest to the Relation class, as done with the url relation in the PR.