### PR TITLE
Fix readme and remove travis config from solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Take a look at the [wiki](https://github.com/avatar29A/MusicBrainz/wiki) or the 
 
 ## Breaking changes in v3
 
-Version 3 removes all code that was marked obsolete in previous versions, specifically the static API and configuration. You should now use the [MusicBrainzClient](https://github.com/avatar29A/MusicBrainz/blob/master/Hqub.MusicBrainz/Hqub.MusicBrainz.API/MusicBrainzClient.cs) class instead. Take a look at the wiki or the examples!
+Version 3 removes all code that was marked obsolete in previous versions, specifically the static API and configuration. You should now use the [MusicBrainzClient](https://github.com/avatar29A/MusicBrainz/blob/master/src/Hqub.MusicBrainz/MusicBrainzClient.cs) class instead. Take a look at the wiki or the examples!
 
 Additionally, the `.API` suffix was removed from the assembly and all namespaces. Fix the namespace change by removing the `.API` suffix in your using statements, for example `using Hqub.MusicBrainz.API` now becomes `using Hqub.MusicBrainz`. The name change of the assembly should be automatically picked up if you are using Nuget to manage package dependencies. Otherwise, you will have to manually fix the reference in your project files.

--- a/src/Hqub.MusicBrainz.sln
+++ b/src/Hqub.MusicBrainz.sln
@@ -19,27 +19,20 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Travis|Any CPU = Travis|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Travis|Any CPU.ActiveCfg = Travis|Any CPU
-		{1E8BEEE2-DF91-4D0B-902E-E661D03E70C3}.Travis|Any CPU.Build.0 = Travis|Any CPU
 		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Travis|Any CPU.ActiveCfg = Travis|Any CPU
-		{A30BD5FD-E8DF-454F-8280-9B1B7093785A}.Travis|Any CPU.Build.0 = Travis|Any CPU
 		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Travis|Any CPU.ActiveCfg = Travis|Any CPU
-		{9FB7E37D-A37B-4262-897F-48291BF836DC}.Travis|Any CPU.Build.0 = Travis|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fix link to `MusicBrainzClient.cs` in README.md and remove the unused Travis configuration from Visual Studio solution file.