### PR TITLE
CreateWebserviceException() fix when 503 BadGataway status code received

### DIFF
--- a/src/Hqub.MusicBrainz/MusicBrainzClient.cs
+++ b/src/Hqub.MusicBrainz/MusicBrainzClient.cs
@@ -171,9 +171,15 @@
         {
             var serializer = new DataContractJsonSerializer(typeof(ResponseError));
 
-            var error = (ResponseError)serializer.ReadObject(stream);
-
-            return new WebServiceException(error.Message, status, url);
+            try
+            {
+                var error = (ResponseError)serializer.ReadObject(stream);
+                return new WebServiceException(error.Message, status, url);
+            }
+            catch
+            {
+                return new WebServiceException(status.ToString(), status, url);
+            }
         }
 
         private static HttpClient CreateHttpClient(Uri baseAddress, bool automaticDecompression, IWebProxy proxy)


### PR DESCRIPTION
If the website is down for maintenance, it returns the 503 error code and the following page causing MusicBrainzClient to throw the System.Runtime.Serialization.SerializationException exception with the following message instead of WebServiceException:

```html
There was an error deserializing the object of type Hqub.MusicBrainz.MusicBrainzClient+ResponseError. Encountered unexpected character '<'.
```
The fix catches any exception that may occur during deserialization and throws the WebServiceException exception instead with the status code as a message.

This is the 503 response page from MusicBrainz:

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-GB" lang="en-GB">
  <head>
    <title>503 Service Unavailable</title>
    <link rel="stylesheet" href="/.custom_error_pages/httperror.css" type="text/css" />
  </head>
  <body>
    <div id="bg">
      <img src="/.custom_error_pages/MusicBrainzLogo-Z.png" />
    </div>
    <h1>Server Maintenance</h1>
    <p>This site is down for maintenance.&nbsp; Please try again later.</p>
    <p id="http">503 Service Unavailable</p>
  </body>
</html>

```