### PR TITLE
Add missing ReleaseEvent field on the Release entity

### DIFF
--- a/src/Hqub.MusicBrainz.Client/Example2.cs
+++ b/src/Hqub.MusicBrainz.Client/Example2.cs
@@ -49,6 +49,19 @@ namespace Hqub.MusicBrainz.Client
             Console.WriteLine("Details for {0} - {1} ({2})", artist.Name, release.Title, release.Date);
             Console.WriteLine();
 
+            // Display release events information if available.
+            if (release.ReleaseEvents != null && release.ReleaseEvents.Count > 0)
+            {
+                Console.WriteLine("Release Events:");
+                foreach (var releaseEvent in release.ReleaseEvents)
+                {
+                    var areaName = releaseEvent.Area?.Name ?? "Unknown Area";
+                    var date = string.IsNullOrEmpty(releaseEvent.Date) ? "Unknown Date" : releaseEvent.Date;
+                    Console.WriteLine("  - {0} ({1})", areaName, date);
+                }
+                Console.WriteLine();
+            }
+
             // Get the medium associated with the release.
             var medium = release.Media.First();
 

--- a/src/Hqub.MusicBrainz.Tests/ReleaseTests.cs
+++ b/src/Hqub.MusicBrainz.Tests/ReleaseTests.cs
@@ -146,5 +146,29 @@ namespace Hqub.MusicBrainz.Tests
             Assert.That(list, Is.Not.Null);
             Assert.That(list.Count, Is.EqualTo(1));
         }
+
+        [Test]
+        public void TestReleaseEvents()
+        {
+            var events = release.ReleaseEvents;
+
+            Assert.That(events, Is.Not.Null);
+            Assert.That(events.Count, Is.EqualTo(1));
+
+            var releaseEvent = events[0];
+
+            Assert.That(releaseEvent, Is.Not.Null);
+            Assert.That(releaseEvent.Date, Is.EqualTo("2012-06-11"));
+
+            var area = releaseEvent.Area;
+
+            Assert.That(area, Is.Not.Null);
+            Assert.That(area.Id, Is.EqualTo("489ce91b-6658-3307-9877-795b68554c98"));
+            Assert.That(area.Name, Is.EqualTo("United States"));
+            Assert.That(area.SortName, Is.EqualTo("United States"));
+            Assert.That(area.IsoCodes, Is.Not.Null);
+            Assert.That(area.IsoCodes.Count, Is.EqualTo(1));
+            Assert.That(area.IsoCodes[0], Is.EqualTo("US"));
+        }
     }
 }

--- a/src/Hqub.MusicBrainz/Entities/Release.cs
+++ b/src/Hqub.MusicBrainz/Entities/Release.cs
@@ -147,6 +147,12 @@ namespace Hqub.MusicBrainz.Entities
         [DataMember(Name = "aliases")]
         public List<Alias> Aliases { get; set; }
 
+        /// <summary>
+        /// Gets or sets a list of release events associated with this release.
+        /// </summary>
+        [DataMember(Name = "release-events")]
+        public List<ReleaseEvent> ReleaseEvents { get; set; }
+
         #endregion
     }
 }

--- a/src/Hqub.MusicBrainz/Entities/ReleaseEvent.cs
+++ b/src/Hqub.MusicBrainz/Entities/ReleaseEvent.cs
@@ -1,0 +1,24 @@
+namespace Hqub.MusicBrainz.Entities
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// A release event represents a date on which a release was released in a specific country/region.
+    /// </summary>
+    /// <see href="https://musicbrainz.org/doc/Release"/>
+    [DataContract(Name = "release-event")]
+    public class ReleaseEvent
+    {
+        /// <summary>
+        /// Gets or sets the area where the release event occurred.
+        /// </summary>
+        [DataMember(Name = "area")]
+        public Area Area { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date of the release event.
+        /// </summary>
+        [DataMember(Name = "date")]
+        public string Date { get; set; }
+    }
+}


### PR DESCRIPTION
- the field was always there, returned by the API, but for some reason wasn't included in the models;

closes #73