### PR TITLE
feat: add missing iso-3166-2 codes for the Area entity and convert IsoCodes to iso-3166-1

### DIFF
--- a/src/Hqub.MusicBrainz.Tests/ArtistTests.cs
+++ b/src/Hqub.MusicBrainz.Tests/ArtistTests.cs
@@ -59,8 +59,8 @@ namespace Hqub.MusicBrainz.Tests
             Assert.That(area.Id, Is.EqualTo("489ce91b-6658-3307-9877-795b68554c98"));
             Assert.That(area.Name, Is.EqualTo("United States"));
 
-            Assert.That(area.IsoCodes, Is.Not.Null);
-            Assert.That(area.IsoCodes.Count, Is.EqualTo(1));
+            Assert.That(area.Iso1Codes, Is.Not.Null);
+            Assert.That(area.Iso1Codes.Count, Is.EqualTo(1));
 
             area = artist.BeginArea;
 

--- a/src/Hqub.MusicBrainz.Tests/LabelTests.cs
+++ b/src/Hqub.MusicBrainz.Tests/LabelTests.cs
@@ -58,8 +58,8 @@ namespace Hqub.MusicBrainz.Tests
             Assert.That(area.Id, Is.EqualTo("85752fda-13c4-31a3-bee5-0e5cb1f51dad"));
             Assert.That(area.Name, Is.EqualTo("Germany"));
 
-            Assert.That(area.IsoCodes, Is.Not.Null);
-            Assert.That(area.IsoCodes.Count, Is.EqualTo(1));
+            Assert.That(area.Iso1Codes, Is.Not.Null);
+            Assert.That(area.Iso1Codes.Count, Is.EqualTo(1));
         }
 
         [Test]

--- a/src/Hqub.MusicBrainz.Tests/ReleaseTests.cs
+++ b/src/Hqub.MusicBrainz.Tests/ReleaseTests.cs
@@ -166,9 +166,9 @@ namespace Hqub.MusicBrainz.Tests
             Assert.That(area.Id, Is.EqualTo("489ce91b-6658-3307-9877-795b68554c98"));
             Assert.That(area.Name, Is.EqualTo("United States"));
             Assert.That(area.SortName, Is.EqualTo("United States"));
-            Assert.That(area.IsoCodes, Is.Not.Null);
-            Assert.That(area.IsoCodes.Count, Is.EqualTo(1));
-            Assert.That(area.IsoCodes[0], Is.EqualTo("US"));
+            Assert.That(area.Iso1Codes, Is.Not.Null);
+            Assert.That(area.Iso1Codes.Count, Is.EqualTo(1));
+            Assert.That(area.Iso1Codes[0], Is.EqualTo("US"));
         }
     }
 }

--- a/src/Hqub.MusicBrainz/Entities/Area.cs
+++ b/src/Hqub.MusicBrainz/Entities/Area.cs
@@ -45,22 +45,6 @@ namespace Hqub.MusicBrainz.Entities
         /// <summary>
         /// Gets or sets the iso-3166-1 codes.
         /// </summary>
-        [Obsolete("Use `Iso1Codes` instead")]
-        public List<string> IsoCodes
-        {
-            get
-            {
-                return Iso1Codes;
-            }
-            set
-            {
-                Iso1Codes = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the iso-3166-1 codes.
-        /// </summary>
         [DataMember(Name = "iso-3166-1-codes")]
         public List<string> Iso1Codes { get; set; }
 

--- a/src/Hqub.MusicBrainz/Entities/Area.cs
+++ b/src/Hqub.MusicBrainz/Entities/Area.cs
@@ -1,6 +1,7 @@
 ﻿
 namespace Hqub.MusicBrainz.Entities
 {
+    using System;
     using System.Collections.Generic;
     using System.Runtime.Serialization;
 
@@ -44,7 +45,29 @@ namespace Hqub.MusicBrainz.Entities
         /// <summary>
         /// Gets or sets the iso-3166-1 codes.
         /// </summary>
+        [Obsolete("Use `Iso1Codes` instead")]
+        public List<string> IsoCodes
+        {
+            get
+            {
+                return Iso1Codes;
+            }
+            set
+            {
+                Iso1Codes = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the iso-3166-1 codes.
+        /// </summary>
         [DataMember(Name = "iso-3166-1-codes")]
-        public List<string> IsoCodes { get; set; }
+        public List<string> Iso1Codes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the iso-3166-2 codes
+        /// </summary>
+        [DataMember(Name = "iso-3166-2-codes")]
+        public List<string> Iso2Codes { get; set; }
     }
 }


### PR DESCRIPTION
Example entity which has only iso-3166-2 codes: https://musicbrainz.org/ws/2/area/0a65a727-7465-4e6c-8b15-ed4d09e021ee?fmt=json